### PR TITLE
MultiWOZ 2.2, 2.3 데이터셋을 사용할 수 있도록 코드 수정.

### DIFF
--- a/create_data.py
+++ b/create_data.py
@@ -310,23 +310,35 @@ def loadData(args):
     data_url = os.path.join(args.main_dir, "data.json")
     if args.mwz_ver == '2.1':
         dataset_url = "https://www.repository.cam.ac.uk/bitstream/handle/1810/294507/MULTIWOZ2.1.zip?sequence=1&isAllowed=y"
+        dir_name = 'MULTIWOZ2.1'
+
+    elif args.mwz_ver == '2.2':
+        dataset_url = "https://github.com/JJinIT/som-dst/raw/feature/MultiWOZ_2x/MultiWOZ_data/MULTIWOZ2.2.zip"
+        dir_name = 'MULTIWOZ2.2'
+
+    elif args.mwz_ver == '2.3':
+        dataset_url = "https://github.com/JJinIT/som-dst/raw/feature/MultiWOZ_2x/MultiWOZ_data/MULTIWOZ2.3.zip"
+        dir_name = 'MULTIWOZ2.3'
+
     else:
         dataset_url = "https://www.repository.cam.ac.uk/bitstream/handle/1810/280608/MULTIWOZ2.zip?sequence=3&isAllowed=y"
+        dir_name = 'MULTIWOZ2 2'
+
     if not os.path.exists(args.main_dir):
         os.makedirs(args.main_dir)
 
-    if not os.path.exists(data_url):
+    if not os.path.exists(os.path.join(args.main_dir, dir_name)):
         print("Downloading and unzipping the MultiWOZ %s dataset" % args.mwz_ver)
         resp = urllib.request.urlopen(dataset_url)
         zip_ref = ZipFile(BytesIO(resp.read()))
         zip_ref.extractall(args.main_dir)
         zip_ref.close()
-        dir_name = 'MULTIWOZ2.1' if args.mwz_ver == '2.1' else 'MULTIWOZ2 2'
-        shutil.copy(os.path.join(args.main_dir, dir_name, 'data.json'), args.main_dir)
-        shutil.copy(os.path.join(args.main_dir, dir_name, 'ontology.json'), args.main_dir)
-        shutil.copy(os.path.join(args.main_dir, dir_name, 'valListFile.json'), args.main_dir)
-        shutil.copy(os.path.join(args.main_dir, dir_name, 'testListFile.json'), args.main_dir)
-        shutil.copy(os.path.join(args.main_dir, dir_name, 'dialogue_acts.json'), args.main_dir)
+
+    shutil.copy(os.path.join(args.main_dir, dir_name, 'data.json'), args.main_dir)
+    shutil.copy(os.path.join(args.main_dir, dir_name, 'ontology.json'), args.main_dir)
+    shutil.copy(os.path.join(args.main_dir, dir_name, 'valListFile.json'), args.main_dir)
+    shutil.copy(os.path.join(args.main_dir, dir_name, 'testListFile.json'), args.main_dir)
+    shutil.copy(os.path.join(args.main_dir, dir_name, 'dialogue_acts.json'), args.main_dir)
 
 
 def getDomain(idx, log, domains, last_domain):


### PR DESCRIPTION
som-dst모델에서 기본적으로 MultiWOZ 2.1을 사용하고 있는데요.
최근에 2.2와 2.3이 릴리즈되어서 최신 데이터셋도 사용할 수 있도록 해보았습니다.
데이터셋은 2.1 포맷으로 컨버팅하여 [JJinIT/som-dst](https://github.com/JJinIT/som-dst/tree/feature/MultiWOZ_2x/MultiWOZ_data)에 wget으로 다운로드 가능하게 해두었구요.
개인적으로 테스트해보니 2.2일떄 조금 더 성능이 잘 나오는것 같네요.
2.3에서는 성능이 현저하게 떨어지는데, 저희쪽 실험 환경이 잘못되었을 수 있습니다.

아래는 Google Colab에서 `batch_size=16`으로 30 epochs 돌리고 얻은 evaluation 결과들입니다.
* 2.1 (baseline)
![image](https://user-images.githubusercontent.com/13341787/102374278-8035fa00-4004-11eb-8e54-c706b78a48c3.png)

* 2.2 (https://github.com/budzianowski/multiwoz/tree/master/data/MultiWOZ_2.2)
![image](https://user-images.githubusercontent.com/13341787/102374328-8cba5280-4004-11eb-9a1e-258e94376a5e.png)

* 2.3 (https://github.com/lexmen318/MultiWOZ-coref)
![image](https://user-images.githubusercontent.com/13341787/102374453-b4a9b600-4004-11eb-8a11-7f8c29919749.png)

cc. @d4rk6un